### PR TITLE
Added .scalaName extension property for Any

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,25 @@ Now you can use `nameOf` to get the name of a variable or class member:
   )
 ```
 
+Alternatively, you can use the extended `.scalaName` property:
+```scala
+  import com.github.dwickern.macros.NameOf._
+
+  case class Person(name: String, age: Int)
+
+  def toMap(person: Person) = Map(
+    person.name.scalaName -> person.name,
+    person.age.scalaName -> person.age
+  )
+
+  // compiles to:
+
+  def toMap(person: Person) = Map(
+    "name" -> person.name,
+    "age" -> person.age
+  )
+```
+
 To get the name of a function:
 ```scala
   import com.github.dwickern.macros.NameOf._

--- a/src/main/scala/com/github/dwickern/macros/NameOf.scala
+++ b/src/main/scala/com/github/dwickern/macros/NameOf.scala
@@ -15,6 +15,19 @@ trait NameOf {
   def nameOf(expr: Any): String = macro NameOfImpl.nameOf
 
   /**
+    * Obtain an identifier name as a constant string via extension.
+    *
+    * Example usage:
+    * {{{
+    *   val amount = 5
+    *   amount.scalaName => "amount"
+    * }}}
+    */
+  implicit class ScalaNamer(member : Any) {
+    def scalaName : String = macro NameOfImpl.scalaName
+  }
+
+  /**
     * Obtain an identifier name as a constant string.
     *
     * This overload can be used to access an instance method without having an instance of the type.

--- a/src/main/scala/com/github/dwickern/macros/NameOfImpl.scala
+++ b/src/main/scala/com/github/dwickern/macros/NameOfImpl.scala
@@ -4,6 +4,13 @@ import scala.annotation.tailrec
 import scala.reflect.macros._
 
 object NameOfImpl {
+  def scalaName(c: Context): c.Expr[String] = {
+    import c.universe._
+
+    val Apply(_, List(expr)) = c.prefix.tree
+    nameOf(c)(c.Expr[Any](expr))
+  }
+
   def nameOf(c: Context)(expr: c.Expr[Any]): c.Expr[String] = {
     import c.universe._
 

--- a/src/test/scala/com/github/dwickern/macros/NameOfTest.scala
+++ b/src/test/scala/com/github/dwickern/macros/NameOfTest.scala
@@ -19,6 +19,7 @@ class NameOfTest extends FunSuite with Matchers {
   test("val") {
     val localVal = ""
     nameOf(localVal) should equal ("localVal")
+    localVal.scalaName should equal ("localVal")
   }
 
   test("symbolic names") {
@@ -40,9 +41,11 @@ class NameOfTest extends FunSuite with Matchers {
 
     def func2(x: Int, y: Int): String = ???
     nameOf(func2 _) should equal ("func2")
+    (func2 _).scalaName should equal ("func2")
 
     def func3(x: Double, y: Int, z: String): Boolean = ???
     nameOf(func3 _) should equal ("func3")
+    (func3 _).scalaName should equal ("func3")
   }
 
   test("curried function") {
@@ -59,12 +62,14 @@ class NameOfTest extends FunSuite with Matchers {
     class SomeClass(val foobar: String)
     val myClass = new SomeClass("")
     nameOf(myClass.foobar) should equal ("foobar")
+    myClass.foobar.scalaName should equal ("foobar")
   }
 
   test("this member") {
     new {
       private[this] val foobar = ""
       nameOf(this.foobar) should equal ("foobar")
+      this.foobar.scalaName should equal ("foobar")
     }
   }
 
@@ -91,6 +96,7 @@ class NameOfTest extends FunSuite with Matchers {
   test("case class") {
     case class CaseClass()
     nameOf(CaseClass) should equal ("CaseClass")
+    CaseClass.scalaName should equal ("CaseClass")
     nameOfType[CaseClass] should equal ("CaseClass")
     qualifiedNameOfType[CaseClass] should equal ("com.github.dwickern.macros.NameOfTest.CaseClass")
   }
@@ -98,6 +104,7 @@ class NameOfTest extends FunSuite with Matchers {
   test("object") {
     object SomeObject
     nameOf(SomeObject) should equal ("SomeObject")
+    SomeObject.scalaName should equal ("SomeObject")
     nameOfType[SomeObject.type] should equal ("SomeObject")
     qualifiedNameOfType[SomeObject.type] should equal ("com.github.dwickern.macros.NameOfTest.SomeObject")
   }


### PR DESCRIPTION
So we now can do `member.scalaName` instead of `nameOf(member)`