### PR TITLE
Add example of usage for methods with arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,20 @@ Without having an instance of the type:
 ```scala
   import com.github.dwickern.macros.NameOf._
 
-  case class Person(name: String, age: Int)
-
+  case class Person(name: String, age: Int) {
+    def sayHello(other: Person) = s"Hello ${other.name}!"
+  }
+  
   println(nameOf[Person](_.age))
 
   // compiles to:
 
   println("age")
+
+  println(nameOf[Person](_.sayHello(???))
+  
+  //compiles to: 
+  println("sayHello")
 ```
 
 You can also use `nameOfType` to get the unqualified name of a type:


### PR DESCRIPTION
It is unclear that istead of writing full function one can use `???` to use underscore notation.
For example, 
```scala
case class Person(name: String, age: Int) {
   def sayHello(other: Person) = s"Hello ${other.name}!"
 }

 //most obvious way
 println(nameOf[Person](p => p.sayHello(_))

//more clear way
println(nameOf[Person](_.sayHello(???)) //note that this doesnt throw exception
```
This PR adds this example to README, but I guess it would be more convenient if this library would provide some other object of type `Nothing` to use instead of `???`