### PR TITLE
add qualifiedNameOf for nested members

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ println("age")
 println("sayHello")
 ```
 
+Without having an instance of the type for nested case classes:
+```scala
+  import com.github.dwickern.macros.NameOf._
+
+  case class Pet(age: Int)
+  case class Person(name: String, pet : Pet)
+
+  println(qualifiedNameOf[Person](_.pet.age))
+
+  // compiles to:
+
+  println("pet.age")
+```
+
 You can also use `nameOfType` to get the unqualified name of a type:
 ```scala mdoc:nest
 println(nameOfType[java.lang.String])

--- a/src/main/scala/com/github/dwickern/macros/NameOf.scala
+++ b/src/main/scala/com/github/dwickern/macros/NameOf.scala
@@ -28,6 +28,20 @@ trait NameOf {
   def nameOf[T](expr: T => Any): String = macro NameOfImpl.nameOf
 
   /**
+    * Obtain a fully qualified identifier name as a constant string.
+    *
+    * This overload can be used to access an instance method without having an instance of the type.
+    *
+    * Example usage:
+    * {{{
+    *   class Pet(val age: Int)
+    *   class Person(val name: String, val pet : Pet)
+    *   nameOf[Person](_.peta.age) => "pet.age"
+    * }}}
+    */
+  def qualifiedNameOf[T](expr: T => Any): String = macro NameOfImpl.qualifiedNameOf
+
+  /**
     * Obtain a type's unqualified name as a constant string.
     *
     * Example usage:

--- a/src/main/scala/com/github/dwickern/macros/NameOfImpl.scala
+++ b/src/main/scala/com/github/dwickern/macros/NameOfImpl.scala
@@ -1,7 +1,7 @@
 package com.github.dwickern.macros
 
 import scala.language.experimental.macros
-import scala.reflect.macros.whitebox
+import scala.reflect.macros.{blackbox, whitebox}
 import scala.annotation.tailrec
 
 object NameOfImpl {
@@ -45,6 +45,37 @@ object NameOfImpl {
       case _ => extract(expr.tree)
     }
     c.Expr[String](q"$name")
+  }
+
+  def qualifiedNameOf(c: blackbox.Context)(expr: c.Expr[Any]): c.Expr[String] = {
+    import c.universe._
+
+    def extractNames(tree: c.Tree): List[c.Name] = {
+      tree.children.headOption match {
+        case Some(child) =>
+          extractNames(child) :+ tree.symbol.name
+        case None =>
+          List(tree.symbol.name)
+      }
+    }
+
+    @tailrec def extract(tree: c.Tree): List[c.Name] = tree match {
+      case Ident(n) => List(n)
+      case Select(tree, n) => extractNames(tree) :+ n
+      case Function(_, body) => extract(body)
+      case Block(_, expr) => extract(expr)
+      case Apply(func, _) => extract(func)
+      case TypeApply(func, _) => extract(func)
+      case _ => c.abort(c.enclosingPosition, s"Unsupported expression: $expr")
+    }
+
+    val name = extract(expr.tree)
+      // drop sth like x$1
+      .drop(1)
+      .mkString(".")
+    reify {
+      c.Expr[String] { Literal(Constant(name)) }.splice
+    }
   }
 
   def nameOfType[T](c: whitebox.Context)(implicit tag: c.WeakTypeTag[T]): c.Expr[String] = {

--- a/src/test/scala/com/github/dwickern/macros/NameOfTest.scala
+++ b/src/test/scala/com/github/dwickern/macros/NameOfTest.scala
@@ -104,6 +104,15 @@ class NameOfTest extends AnyFunSuite with Matchers {
     qualifiedNameOfType[CaseClass] should equal ("com.github.dwickern.macros.NameOfTest.CaseClass")
   }
 
+  test("nested case class member") {
+    case class Nested3CaseClass(member: String)
+    case class Nested2CaseClass(nested3CaseClass: Nested3CaseClass)
+    case class Nested1CaseClass(nested2CaseClass: Nested2CaseClass)
+    case class CaseClass(nested1CaseClass: Nested1CaseClass)
+
+    qualifiedNameOf[CaseClass](_.nested1CaseClass.nested2CaseClass.nested3CaseClass.member) should equal("nested1CaseClass.nested2CaseClass.nested3CaseClass.member")
+  }
+
   test("object") {
     object SomeObject
     nameOf(SomeObject) should equal ("SomeObject")


### PR DESCRIPTION
My usecase is querying ElasticSearch where nested case classes have been inserted.

I'm really not sure about the implementation as I'm not too familiar with macros. Tbh I'm surprised I got it to work at all.. But the test passes ;)